### PR TITLE
Updated map to use higher order messages

### DIFF
--- a/src/HoursHelper.php
+++ b/src/HoursHelper.php
@@ -41,7 +41,7 @@ class HoursHelper
 
                 return false;
             })
-            ->map(fn (Carbon $carbon) => $carbon->format($format))
+            ->map->format($format)
             ->values();
     }
 }


### PR DESCRIPTION
You don't need to pass the callback to map in Laravel. You can simply pass the format to map as the returned type is already of Carbon.

All tests pass still.